### PR TITLE
#4276 upgrade user-messages to be compatible with python3 and django1.11

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.txt'
 master_doc = 'index'
 
 # General information about the project.
-project = u'user-messages'
-copyright = u'2011, Eldarion'
+project = 'user-messages'
+copyright = '2011, Eldarion'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -178,8 +178,8 @@ htmlhelp_basename = 'usermessagesdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'user-messages.tex', u'user-messages Documentation',
-   u'Eldarion', 'manual'),
+  ('index', 'user-messages.tex', 'user-messages Documentation',
+   'Eldarion', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -211,6 +211,6 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'user-messages', u'user-messages Documentation',
-     [u'Eldarion'], 1)
+    ('index', 'user-messages', 'user-messages Documentation',
+     ['Eldarion'], 1)
 ]

--- a/user_messages/context_processors.py
+++ b/user_messages/context_processors.py
@@ -4,5 +4,5 @@ from user_messages.models import Thread
 def user_messages(request):
     c = {}
     if request.user.is_authenticated():
-        c["inbox_count"] = Thread.objects.inbox(request.user).count()
+        c["inbox_count"] = Thread.objects.unread_threads(request.user).count()
     return c

--- a/user_messages/forms.py
+++ b/user_messages/forms.py
@@ -62,6 +62,10 @@ class NewMessageForm(forms.Form):
         super(NewMessageForm, self).clean()
         users = self.cleaned_data.get("to_users")
         groups = self.cleaned_data.get("to_groups")
+        if users is None and groups is None:
+            # when data in field users/groups is not valid,
+            # cleaned_data function will not include the data or its field
+            raise ValidationError(_("Must have at least one validated user or group."))
         if not any(users) and not any(groups):
             raise ValidationError(_("Must select at least one user or group."))
 

--- a/user_messages/migrations/0001_initial.py
+++ b/user_messages/migrations/0001_initial.py
@@ -18,7 +18,6 @@
 #
 #########################################################################
 
-from __future__ import unicode_literals
 
 from django.db import migrations, models
 import django.utils.timezone

--- a/user_messages/migrations/0002_auto_20171107_1128.py
+++ b/user_messages/migrations/0002_auto_20171107_1128.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 import django.utils.timezone

--- a/user_messages/migrations/0003_auto_20171108_1037.py
+++ b/user_messages/migrations/0003_auto_20171108_1037.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 from django.conf import settings

--- a/user_messages/migrations/0004_auto_20171108_1101.py
+++ b/user_messages/migrations/0004_auto_20171108_1101.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/user_messages/models.py
+++ b/user_messages/models.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models import Q

--- a/user_messages/tests/manage.py
+++ b/user_messages/tests/manage.py
@@ -1,12 +1,16 @@
-#!/usr/bin/env python
-from django.core.management import execute_manager
-try:
-    import settings # Assumed to be in the same directory.
-except ImportError:
-    import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)
-    sys.exit(1)
+import os
+import sys
+import django
+from django.conf import settings
+from django.test.utils import get_runner
+
+
+os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 
 if __name__ == "__main__":
-    execute_manager(settings)
-
+    django.setup()
+    TestRunner = get_runner(settings)
+    test_runner = TestRunner()
+    failures = test_runner.run_tests(['user_messages'])
+    if failures:
+        sys.exit(failures)

--- a/user_messages/tests/settings.py
+++ b/user_messages/tests/settings.py
@@ -1,14 +1,68 @@
-DATABASE_ENGINE = "sqlite3"
+import os
 
 ROOT_URLCONF = "user_messages.urls"
 
-TEMPLATE_CONTEXT_PROCESSORS = [
-    "user_messages.context_processors.user_messages"
+SECRET_KEY = " "
+
+AUTHENTICATION_BACKENDS = ('django.contrib.auth.backends.ModelBackend', 'guardian.backends.ObjectPermissionBackend')
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'file': {
+            'level': 'DEBUG',
+            'class': 'logging.FileHandler',
+            'filename': 'debug.log',
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['file'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+    },
+}
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [os.path.join(BASE_DIR, 'tests/templates')],
+        'APP_DIRS': False,
+        'OPTIONS': {
+            'context_processors': [
+                "user_messages.context_processors.user_messages"
+            ]
+        }
+    },
 ]
 
 INSTALLED_APPS = [
-    "django.contrib.auth",
-    "django.contrib.contenttypes",
-    "django.contrib.sessions",
+    'django.contrib.auth',
+    'django.contrib.sessions',
+    'django.contrib.sites', 
+    'django.contrib.contenttypes',
     "user_messages",
+    'guardian',
+    'geonode.groups',
+    "taggit",
 ]
+
+
+MIDDLEWARE = [
+    'django.middleware.common.CommonMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+]
+
+USE_TZ = True

--- a/user_messages/tests/test_forms.py
+++ b/user_messages/tests/test_forms.py
@@ -1,7 +1,6 @@
 """Unit tests for user_messages.forms"""
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.test import TestCase
 
 from geonode.groups.models import GroupProfile
@@ -109,7 +108,7 @@ class NewMessageFormTestCase(TestCase):
             {
                 "subject": "dummy subject",
                 "content": "dummy content",
-                "to_users": [2,],
+                "to_users": [self.second_user.id,],
                 "to_groups": [],
             },
             current_user=self.first_user
@@ -122,7 +121,7 @@ class NewMessageFormTestCase(TestCase):
                 "subject": "dummy subject",
                 "content": "dummy content",
                 "to_users": [],
-                "to_groups": [1, 2],
+                "to_groups": [self.second_group.id, self.first_group.id],
             },
             current_user=self.first_user
         )

--- a/user_messages/tests/test_managers.py
+++ b/user_messages/tests/test_managers.py
@@ -1,7 +1,6 @@
 """Unit tests for user_messages.managers."""
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.test import TestCase
 import mock
 

--- a/user_messages/tests/test_models.py
+++ b/user_messages/tests/test_models.py
@@ -1,7 +1,6 @@
 """Unit tests for user_messages.models."""
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 


### PR DESCRIPTION
The changes made for geonode-user-messages are to meet the compatibility requirement for python3 and django 1.11. The original code contains outdated django modules which would break in django versions >= 1.4.

Main changes:

- update importings and syntaxes to be compatible with python3 
- modify instance names and functions to be compatible with django1.11
- structural changes in settings.py and manage.py to meet django1.11 coding formats
- minor changes after running flake8

The code runs in a python3 environment, to test run the command `python manage.py test `assuming the current directory is ../user_messages/test and the python environment is python3.
