### PR TITLE
FIX #18 Mark usermember thread as read

### DIFF
--- a/user_messages/views.py
+++ b/user_messages/views.py
@@ -40,6 +40,7 @@ def thread_detail(request, thread_id,
     else:
         form = MessageReplyForm(user=request.user, thread=thread)
         thread.userthread_set.filter(user=request.user).update(unread=False)
+        thread.groupmemberthread_set.filter(user=request.user).update(unread=False)
     return render(request, template_name, context={
         "thread": thread,
         "form": form


### PR DESCRIPTION
Fix [#18]
Mark groupmember threads as read after opening it

https://github.com/GeoNode/geonode-user-messages/issues/18